### PR TITLE
adding a recorder script as a potential alternative to the built-in unity recorder

### DIFF
--- a/Assets/Scenes/Demo3.unity
+++ b/Assets/Scenes/Demo3.unity
@@ -742,7 +742,7 @@ Camera:
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 2
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 1}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0

--- a/Assets/Scenes/Recorder.cs
+++ b/Assets/Scenes/Recorder.cs
@@ -1,0 +1,90 @@
+using System.Collections;
+using UnityEngine;
+using UnityEditor;
+using System.IO;
+
+// potentially helpful
+// https://docs.unity3d.com/ScriptReference/MonoBehaviour.FixedUpdate.html
+// https://docs.unity3d.com/ScriptReference/Texture2D.ReadPixels.html
+// https://www.reddit.com/r/Unity3D/comments/8oo6d6/waitforseconds_framerate_dependant/
+
+public class Recorder : MonoBehaviour
+{
+    public float framesPerSec = 12f;
+    public string folderName = "test";
+
+    string dirPath = "";
+    int snapshotCounter = 0;
+    bool isCapturing = false;
+    float intervalTime;
+
+    public void Awake()
+    {
+        EditorApplication.playModeStateChanged += LogPlayModeState;
+    }
+
+    private void LogPlayModeState(PlayModeStateChange state)
+    {
+        //Debug.Log(state);
+        if (state.Equals(PlayModeStateChange.EnteredPlayMode)) //state.Equals(PlayModeStateChange.ExitingEditMode)
+        {
+            Debug.Log("i'm playing!");
+            snapshotCounter = 0;
+            isCapturing = true;
+            intervalTime = 1 / framesPerSec; // e.g. if 12 fps, every ~0.08 sec we should take a new snapshot
+
+            bool dirCreated = createNewDirectoryForSnapshots();
+            if (dirCreated)
+            {
+                // start capturing
+                StartCoroutine(takeSnapshots());
+            }
+        }
+        else if(state.Equals(PlayModeStateChange.ExitingPlayMode))
+        {
+            Debug.Log("i'm done");
+
+            // stop capturing
+            isCapturing = false;
+            StopAllCoroutines();
+        }
+    }
+
+    bool createNewDirectoryForSnapshots()
+    {
+        try
+        {
+            Debug.Log(Application.dataPath);
+            dirPath = Application.dataPath + "/../" + folderName;
+            Directory.CreateDirectory(dirPath);
+            return true;
+        }
+        catch(IOException exception)
+        {
+            Debug.Log(exception);
+            return false;
+        }
+    }
+
+    IEnumerator takeSnapshots()
+    {
+        while (isCapturing)
+        {
+            StartCoroutine(getSnapshot());
+            yield return new WaitForSecondsRealtime(intervalTime);
+        }
+    }
+
+    IEnumerator getSnapshot()
+    {
+        yield return new WaitForEndOfFrame();
+        Texture2D tex = new Texture2D(Screen.width, Screen.height, TextureFormat.ARGB32, false);
+        tex.ReadPixels(new Rect(0, 0, Screen.width, Screen.height), 0, 0); // capture screen
+        //tex.Apply();
+        byte[] bytes = tex.EncodeToPNG();
+        File.WriteAllBytes(dirPath + "/" + snapshotCounter.ToString() + ".png", bytes);
+        Destroy(tex);
+        snapshotCounter++;
+    }
+
+}

--- a/notes/notes.txt
+++ b/notes/notes.txt
@@ -18,3 +18,15 @@ TODO:
 - more sample scenes, more code refactoring for easier re-use
 - figure out recorder (why does it lag majorly initially when I turn it on?), output video quality
 - test with multiple audio sources, not just one
+
+about the recorder.cs file 
+- an attempt at an alternative to the built-in Unity Recorder
+- captures frames of the editor and puts them in a dir
+- how to use: attach it to the Main Camera of a scene
+- press play
+- stop when the audio ends (yeah this is manual atm lol :/)
+- then use ffmpeg to create an mp4 or whatever with the captured frames and audio file
+  - might have to fiddle with the framerate flag a bit when using ffmpeg as the frame capture rate might have been inaccurate
+
+ffmpeg example with recorder.cs output:
+ffmpeg -framerate 10 -i frames/%d.png -i audio.wav -c:v libx264 -vf "pad=ceil(iw/2)*2:ceil(ih/2)*2" -preset slow -crf 22 -pix_fmt yuv420p -b:a 128k output.mp4


### PR DESCRIPTION
the built-in Unity recorder is a bit annoying because it always seems to clip the first second of audio for recordings so I wanted an alternative. 

this recorder script just captures frames of the editor window when playing. it's not perfect but I think it seems to kinda work ok at least so far (at least for my purposes atm).

things to note:
- the capturing ends when the player is stopped
- timing of frame capture may be inaccurate
- need ffmpeg to put the captured frames together with the audio file as a video file (e.g. mp4). the frame rate used for ffmpeg might need to be adjusted and may not be the same as the "frame rate" specified for the recorder script